### PR TITLE
:sparkles: enable rate limit from nginx

### DIFF
--- a/script/nginx-rate-limit.conf
+++ b/script/nginx-rate-limit.conf
@@ -1,0 +1,13 @@
+limit_req_zone $binary_remote_addr zone=ip_rate_limit:10m rate=5r/s;
+limit_req_status 429;
+
+server {
+
+	server_name api.saltynote.com;
+
+	location /v1/ {
+		limit_req zone=ip_rate_limit;
+		# other lines
+		proxy_pass http://service/;
+	}
+}


### PR DESCRIPTION
For now, allow 5 request per second for a single client IP.

<img width="588" alt="image" src="https://user-images.githubusercontent.com/2281521/231906880-bbefcfa1-3d2f-4a01-8264-e387dad65152.png">
